### PR TITLE
feat: enable sash size to be customised in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ You can customize the following default variables.
 ```css
 :root {
   --focus-border: #007fd4;
-  --sash-size: 8px;
-  --sash-hover-size: 4px;
   --separator-border: #838383;
 }
 ```
+
+To control the feedback area size of the dragging area between panes you can call the exported `setSashSize` function with desired size in pixels. Set it to a larger value if you feel it's hard to resize the panes using the mouse. On touch devices the feedback area is always set to 20 pixels
 
 ### Programmatic control
 

--- a/src/allotment.tsx
+++ b/src/allotment.tsx
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import clamp from "lodash.clamp";
 import React, {
   forwardRef,
   useEffect,
@@ -10,7 +11,8 @@ import React, {
 import useResizeObserver from "use-resize-observer";
 
 import styles from "./allotment.module.css";
-import { Orientation } from "./sash";
+import { isIOS } from "./helpers/platform";
+import { Orientation, setGlobalSashSize } from "./sash";
 import { Sizing, SplitView, SplitViewOptions } from "./split-view/split-view";
 
 function isPane(item: React.ReactNode): item is typeof Pane {
@@ -51,6 +53,11 @@ export type AllotmentProps = {
    */
   defaultSizes?: number[];
   /**
+   * Controls the feedback area size in pixels of the dragging area in between panes.
+   * Set it to a larger value if you feel it's hard to resize panes using the mouse.
+   */
+  sashSize?: number;
+  /**
    * Initial size of each element
    * @deprecated Use {@link AllotmentProps.defaultSizes defaultSizes} instead
    */
@@ -67,6 +74,7 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       children,
       maxSize = Infinity,
       minSize = 30,
+      sashSize = isIOS ? 20 : 4,
       sizes,
       defaultSizes = sizes,
       snap = false,
@@ -192,6 +200,19 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
         previousKeys.current = keys;
       }
     }, [childrenArray, maxSize, minSize, snap]);
+
+    useEffect(() => {
+      const size = clamp(sashSize, 4, 20);
+      const hoverSize = clamp(sashSize, 1, 8);
+
+      document.documentElement.style.setProperty("--sash-size", size + "px");
+      document.documentElement.style.setProperty(
+        "--sash-hover-size",
+        hoverSize + "px"
+      );
+
+      setGlobalSashSize(size);
+    }, [sashSize]);
 
     useResizeObserver({
       ref: containerRef,

--- a/src/allotment.tsx
+++ b/src/allotment.tsx
@@ -11,7 +11,6 @@ import React, {
 import useResizeObserver from "use-resize-observer";
 
 import styles from "./allotment.module.css";
-import { isIOS } from "./helpers/platform";
 import { Orientation, setGlobalSashSize } from "./sash";
 import { Sizing, SplitView, SplitViewOptions } from "./split-view/split-view";
 
@@ -53,11 +52,6 @@ export type AllotmentProps = {
    */
   defaultSizes?: number[];
   /**
-   * Controls the feedback area size in pixels of the dragging area in between panes.
-   * Set it to a larger value if you feel it's hard to resize panes using the mouse.
-   */
-  sashSize?: number;
-  /**
    * Initial size of each element
    * @deprecated Use {@link AllotmentProps.defaultSizes defaultSizes} instead
    */
@@ -74,7 +68,6 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       children,
       maxSize = Infinity,
       minSize = 30,
-      sashSize = isIOS ? 20 : 4,
       sizes,
       defaultSizes = sizes,
       snap = false,
@@ -201,19 +194,6 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       }
     }, [childrenArray, maxSize, minSize, snap]);
 
-    useEffect(() => {
-      const size = clamp(sashSize, 4, 20);
-      const hoverSize = clamp(sashSize, 1, 8);
-
-      document.documentElement.style.setProperty("--sash-size", size + "px");
-      document.documentElement.style.setProperty(
-        "--sash-hover-size",
-        hoverSize + "px"
-      );
-
-      setGlobalSashSize(size);
-    }, [sashSize]);
-
     useResizeObserver({
       ref: containerRef,
       onResize: ({ width, height }) => {
@@ -278,5 +258,18 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
 );
 
 Allotment.displayName = "Allotment";
+
+export function setSashSize(sashSize: number) {
+  const size = clamp(sashSize, 4, 20);
+  const hoverSize = clamp(sashSize, 1, 8);
+
+  document.documentElement.style.setProperty("--sash-size", size + "px");
+  document.documentElement.style.setProperty(
+    "--sash-hover-size",
+    hoverSize + "px"
+  );
+
+  setGlobalSashSize(size);
+}
 
 export default Object.assign(Allotment, { Pane: Pane });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export { default as Allotment } from "./allotment";
+export type { AllotmentHandle, AllotmentProps } from "./allotment";
+export { default as Allotment, setSashSize } from "./allotment";

--- a/src/sash/sash.module.css
+++ b/src/sash/sash.module.css
@@ -114,12 +114,12 @@
 
 .sash.vertical:before {
   width: var(--sash-hover-size);
-  left: calc(50% - var(--sash-hover-size) / 2);
+  left: calc(50% - (var(--sash-hover-size) / 2));
 }
 
 .sash.horizontal:before {
   height: var(--sash-hover-size);
-  top: calc(50% - var(--sash-hover-size) / 2);
+  top: calc(50% - (var(--sash-hover-size) / 2));
 }
 
 .sash.hover:before,

--- a/src/sash/sash.ts
+++ b/src/sash/sash.ts
@@ -29,7 +29,7 @@ export enum SashState {
   Enabled = "ENABLED",
 }
 
-let globalSize = 4;
+let globalSize = isIOS ? 20 : 8;
 
 const onDidChangeGlobalSize = new EventEmitter();
 

--- a/src/sash/sash.ts
+++ b/src/sash/sash.ts
@@ -123,7 +123,7 @@ export class Sash extends EventEmitter implements Disposable {
     } else {
       this.size = globalSize;
 
-      onDidChangeGlobalSize.addListener("onDidChangeGlobalSize", (size) => {
+      onDidChangeGlobalSize.on("onDidChangeGlobalSize", (size) => {
         this.size = size;
         this.layout();
       });

--- a/stories/allotment.stories.tsx
+++ b/stories/allotment.stories.tsx
@@ -209,14 +209,30 @@ export const Reset: Story<AllotmentProps> = (args) => {
 };
 Reset.args = {};
 
-export const DefaultSize: Story = () => {
+export const DefaultSize: Story<AllotmentProps> = (args) => {
   return (
     <div className={styles.container}>
-      <Allotment defaultSizes={[200, 400]}>
+      <Allotment {...args}>
         <div className={styles.content}>div1</div>
         <div className={styles.content}>div2</div>
       </Allotment>
     </div>
   );
 };
-DefaultSize.args = {};
+DefaultSize.args = {
+  defaultSizes: [200, 400],
+};
+
+export const ConfigureSash: Story<AllotmentProps> = (args) => {
+  return (
+    <div className={styles.container}>
+      <Allotment {...args}>
+        <div className={styles.content}>div1</div>
+        <div className={styles.content}>div2</div>
+      </Allotment>
+    </div>
+  );
+};
+ConfigureSash.args = {
+  sashSize: 4,
+};

--- a/stories/allotment.stories.tsx
+++ b/stories/allotment.stories.tsx
@@ -2,7 +2,12 @@ import { Meta, Story } from "@storybook/react";
 import { debounce } from "lodash";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import Allotment, { AllotmentHandle, AllotmentProps } from "../src/allotment";
+import {
+  Allotment,
+  AllotmentHandle,
+  AllotmentProps,
+  setSashSize,
+} from "../src";
 import { range } from "../src/helpers/range";
 import styles from "./allotment.stories.module.css";
 
@@ -223,7 +228,11 @@ DefaultSize.args = {
   defaultSizes: [200, 400],
 };
 
-export const ConfigureSash: Story<AllotmentProps> = (args) => {
+export const ConfigureSash: Story = ({ sashSize, ...args }) => {
+  useEffect(() => {
+    setSashSize(sashSize);
+  }, [sashSize]);
+
   return (
     <div className={styles.container}>
       <Allotment {...args}>


### PR DESCRIPTION
This PR currently sets the sash size globally for all Allotment components. Obviously, setting a prop on a React component should only affect that component. We can either address this in this PR or leave this undocumented for now and tidy up in a follow-up PR.