### PR TITLE
fix: call cancel hover after pointer up

### DIFF
--- a/src/sash/sash.ts
+++ b/src/sash/sash.ts
@@ -226,7 +226,7 @@ export class Sash extends EventEmitter implements Disposable {
       event.preventDefault();
 
       this.el.classList.remove(styles.active);
-
+      this.hoverDelayer.cancel();
       this.emit("end");
 
       this.el.releasePointerCapture(event.pointerId);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
This PR fixes #102 . The problem was on touch devices, ```mouseenter``` event is activated on touch causing ```sash.hover``` to be present in the div without ever calling ```mouseleave``` event.
<!--- Describe your changes in detail -->

# Related Issue
#102

# How Has This Been Tested?
Manual Testing on chrome dev tools 

# Screenshots (if appropriate):
![dblclick](https://user-images.githubusercontent.com/33824219/150230024-3820ebbc-0fb3-4b0e-b80d-1460a2dc0ee5.gif)
