### PR TITLE
feat: add onReset callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Direction to split. If true then the panes will be stacked vertically, otherwise
 
 Callback that is fired when the pane sizes change (usually on drag). Recommended to add a debounce function to rate limit the callback. Passed an array of numbers.
 
+### onReset
+
+Callback that is fired whenever the user double clicks a sash.
+
 ## Allotment.Pane props
 
 ### maxSize

--- a/src/allotment.tsx
+++ b/src/allotment.tsx
@@ -151,8 +151,11 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       );
 
       splitViewRef.current.on("sashreset", (_index: number) => {
-        onReset?.();
-        splitViewRef.current?.distributeViewSizes();
+        if (onReset) {
+          onReset();
+        } else {
+          splitViewRef.current?.distributeViewSizes();
+        }
       });
 
       const that = splitViewRef.current;

--- a/src/allotment.tsx
+++ b/src/allotment.tsx
@@ -61,6 +61,8 @@ export type AllotmentProps = {
   vertical?: boolean;
   /** Callback on drag */
   onChange?: (sizes: number[]) => void;
+  /** Callback on reset */
+  onReset?: () => void;
 } & CommonProps;
 
 const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
@@ -74,6 +76,7 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       snap = false,
       vertical = false,
       onChange,
+      onReset,
     },
     ref
   ) => {
@@ -148,6 +151,7 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       );
 
       splitViewRef.current.on("sashreset", (_index: number) => {
+        onReset?.();
         splitViewRef.current?.distributeViewSizes();
       });
 

--- a/stories/allotment.stories.tsx
+++ b/stories/allotment.stories.tsx
@@ -239,6 +239,7 @@ export const OnReset: Story = (args) => {
   const ref = useRef<AllotmentHandle>(null!);
 
   const handleReset = () => {
+    ref.current.reset();
     alert("reset");
   };
 

--- a/stories/allotment.stories.tsx
+++ b/stories/allotment.stories.tsx
@@ -15,11 +15,6 @@ import { Content } from "./content";
 export default {
   title: "Basic",
   Component: Allotment,
-  argTypes: {
-    numViews: {
-      control: { type: "number", min: 1, max: 10, step: 1 },
-    },
-  },
 } as Meta;
 
 export const Simple: Story = () => (
@@ -239,3 +234,21 @@ export const ConfigureSash: Story = ({ sashSize, ...args }) => {
 ConfigureSash.args = {
   sashSize: 4,
 };
+
+export const OnReset: Story = (args) => {
+  const ref = useRef<AllotmentHandle>(null!);
+
+  const handleReset = () => {
+    alert("reset");
+  };
+
+  return (
+    <div className={styles.container}>
+      <Allotment ref={ref} {...args} onReset={handleReset}>
+        <Content />
+        <Content />
+      </Allotment>
+    </div>
+  );
+};
+OnReset.args = {};

--- a/website/docs/allotment.md
+++ b/website/docs/allotment.md
@@ -14,3 +14,4 @@ title: Allotment
 | `minSize`      | `number`   |         | Minimum size of any pane.                                                                                                                                   |
 | `snap`         | `boolean`  | `false` | Enable snap to zero for all panes.                                                                                                                          |
 | `vertical`     | `boolean`  | `false` | Direction to split. If true then the panes will be stacked vertically, otherwise they will be stacked horizontally.                                         |
+| `onReset`      | `func`     |         | Callback that is fired whenever the user double clicks a sash                                                                                               |


### PR DESCRIPTION
Adds an `onReset` callback to enable you to customise behaviour. Note that providing a value for the callback prevents the default behaviour of evenly distributing the space.