### PR TITLE
fix: initial visible bug

### DIFF
--- a/src/allotment.tsx
+++ b/src/allotment.tsx
@@ -11,6 +11,7 @@ import React, {
 import useResizeObserver from "use-resize-observer";
 
 import styles from "./allotment.module.css";
+import { repeat } from "./helpers/array";
 import { isIOS } from "./helpers/platform";
 import { Orientation, setGlobalSashSize } from "./sash";
 import { Sizing, SplitView, SplitViewOptions } from "./split-view/split-view";
@@ -136,7 +137,7 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
         );
       }
 
-      if (initializeSizes && defaultSizes) {
+      if (initializeSizes) {
         previousKeys.current = childrenArray.map(
           (child) => child.key as string
         );
@@ -145,23 +146,25 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       const options: SplitViewOptions = {
         orientation: vertical ? Orientation.Vertical : Orientation.Horizontal,
         proportionalLayout,
-        ...(initializeSizes &&
-          defaultSizes && {
-            descriptor: {
-              size: defaultSizes.reduce((a, b) => a + b, 0),
-              views: defaultSizes.map((size, index) => ({
-                container: [...splitViewViewRef.current.values()][index],
-                size: size,
-                view: {
-                  element: document.createElement("div"),
-                  minimumSize: minSize,
-                  maximumSize: maxSize,
-                  snap: snap,
-                  layout: () => {},
-                },
-              })),
-            },
-          }),
+        ...(initializeSizes && {
+          descriptor: {
+            size: defaultSizes ? defaultSizes.reduce((a, b) => a + b, 0) : 0,
+            views: (
+              defaultSizes ||
+              repeat(Sizing.Distribute, splitViewViewRef.current.size)
+            ).map((size, index) => ({
+              container: [...splitViewViewRef.current.values()][index],
+              size: size,
+              view: {
+                element: document.createElement("div"),
+                minimumSize: minSize,
+                maximumSize: maxSize,
+                snap: snap,
+                layout: () => {},
+              },
+            })),
+          },
+        }),
       };
 
       splitViewRef.current = new SplitView(

--- a/src/allotment.tsx
+++ b/src/allotment.tsx
@@ -152,17 +152,22 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
             views: (
               defaultSizes ||
               repeat(Sizing.Distribute, splitViewViewRef.current.size)
-            ).map((size, index) => ({
-              container: [...splitViewViewRef.current.values()][index],
-              size: size,
-              view: {
-                element: document.createElement("div"),
-                minimumSize: minSize,
-                maximumSize: maxSize,
-                snap: snap,
-                layout: () => {},
-              },
-            })),
+            ).map((size, index) => {
+              const props = splitViewPropsRef.current.get(
+                previousKeys.current[index]
+              );
+              return {
+                container: [...splitViewViewRef.current.values()][index],
+                size: size,
+                view: {
+                  element: document.createElement("div"),
+                  minimumSize: props?.minSize ?? minSize,
+                  maximumSize: props?.maxSize ?? maxSize,
+                  snap: props?.snap ?? snap,
+                  layout: () => {},
+                },
+              };
+            }),
           },
         }),
       };

--- a/src/helpers/array.ts
+++ b/src/helpers/array.ts
@@ -29,3 +29,14 @@ export function range(start: number, stop: number, step: number = 1): number[] {
 
   return range;
 }
+
+/**
+ * Creates an array from an item with the specified length
+ *
+ * @param item Any item
+ * @param length The length of the resulting array
+ * @returns An array of the item repeated length times
+ */
+export function repeat<T>(item: T, length: number): T[] {
+  return Array.from(Array(length)).map(() => item);
+}

--- a/src/split-view/split-view.ts
+++ b/src/split-view/split-view.ts
@@ -76,7 +76,7 @@ export interface SplitViewDescriptor {
     visible?: boolean;
 
     /** The size of the {@link View view}. */
-    size: number;
+    size: number | DistributeSizing;
 
     container: HTMLElement;
     view: View;

--- a/stories/allotment.stories.tsx
+++ b/stories/allotment.stories.tsx
@@ -288,7 +288,7 @@ export const PaneClassName: Story = (args) => {
 };
 
 export const Visible: Story<AllotmentProps> = (args) => {
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useState(true);
 
   return (
     <div>
@@ -312,9 +312,7 @@ export const Visible: Story<AllotmentProps> = (args) => {
     </div>
   );
 };
-Visible.args = {
-  defaultSizes: [400, 100],
-};
+Visible.args = {};
 
 export const OnReset: Story = (args) => {
   const ref = useRef<AllotmentHandle>(null!);


### PR DESCRIPTION
Without setting `defaultSizes`, when a pane is initially visible, toggling visibility results in a weird bug where the layout is shifted as if there were an additional pane. 

To fix this, I added a "default" descriptor for views when `defaultSizes` is not set.

It's not really clear to me why this works, because it pretty much does the same thing as the `for (const enterKey of enter) {...}` block.

