### PR TITLE
fix: initialize dimensions before first paint

### DIFF
--- a/src/allotment.tsx
+++ b/src/allotment.tsx
@@ -451,6 +451,15 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       },
     });
 
+    useIsomorphicLayoutEffect(() => {
+      if (!dimensionsInitialized) {
+        const { height, width } = containerRef.current.getBoundingClientRect();
+        splitViewRef.current?.layout(vertical ? height : width);
+        layoutService.current.setSize(vertical ? height : width);
+        setDimensionsInitialized(true);
+      }
+    }, [dimensionsInitialized, vertical]);
+
     useEffect(() => {
       if (isIOS) {
         setSashSize(20);


### PR DESCRIPTION
The container dimensions are in the `ResizeObserver` callback. It fires only after the first paint. This means that the dimensions are not initialized during the first paint, which causes a layout shift.

The dimensions are known before the first paint. We can retrieve the container width and height by using `getBoundingClientRect` inside `useLayoutEffect`. This way we can initialize the dimensions correctly so the panes are already sized the right way during the first render.

## Videos

Here are videos from the initial render before and after the fix. I suspect this bug is only noticeable when there are many `useLayoutEffect`/`useEffect`/React elements to render, as the delay between the first and second paint is greater in these cases.

Before the fix:

https://user-images.githubusercontent.com/889383/211844214-37672b6e-dcd3-42d5-ae63-eb9e43a72210.mp4

After the fix:

https://user-images.githubusercontent.com/889383/211844221-1ccb487b-1d37-4c24-8287-09c6c6e7a444.mp4

