### PR TITLE
Add `onChangeEnd` handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Direction to split. If true then the panes will be stacked vertically, otherwise
 
 Callback that is fired when the pane sizes change (usually on drag). Recommended to add a debounce function to rate limit the callback. Passed an array of numbers.
 
+### onChangeEnd
+
+Callback that is fired *once* when the pane sizes change (when a drag ends, or when the layout is reset). It's the same idea as `onChange`, but only gets called once per drag-interaction.
+
 ### onReset
 
 Callback that is fired whenever the user double clicks a sash.

--- a/src/allotment.tsx
+++ b/src/allotment.tsx
@@ -111,7 +111,7 @@ export type AllotmentProps = {
   /** Callback on drag */
   onChange?: (sizes: number[]) => void;
   /** Callback when user stops dragging the sash*/
-  onDragEnd?: (sizes: number[]) => void;
+  onChangeEnd?: (sizes: number[]) => void;
   /** Callback on reset */
   onReset?: () => void;
   /** Callback on visibility change */
@@ -135,7 +135,7 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       snap = false,
       vertical = false,
       onChange,
-      onDragEnd,
+      onChangeEnd,
       onReset,
       onVisibleChange,
     }: AllotmentProps,
@@ -185,6 +185,7 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
             resizeToPreferredSize(index);
           }
         }
+        onChangeEnd?.(splitViewRef.current?.getViewSizes() ?? []);
       },
       resize: (sizes) => {
         splitViewRef.current?.resizeViews(sizes);
@@ -250,7 +251,7 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
         containerRef.current,
         options,
         onChange,
-        onDragEnd
+        onChangeEnd
       );
 
       splitViewRef.current.on("sashDragStart", () => {
@@ -293,6 +294,7 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
 
           splitViewRef.current?.distributeViewSizes();
         }
+        onChangeEnd?.(splitViewRef.current?.getViewSizes() ?? []);
       });
 
       const that = splitViewRef.current;
@@ -453,9 +455,9 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
     
     useEffect(() => {
       if (splitViewRef.current) {
-        splitViewRef.current.onDragEnd = onDragEnd;
+        splitViewRef.current.onChangeEnd = onChangeEnd;
       }
-    }, [onDragEnd])
+    }, [onChangeEnd])
 
     useResizeObserver({
       ref: containerRef,

--- a/src/allotment.tsx
+++ b/src/allotment.tsx
@@ -110,6 +110,8 @@ export type AllotmentProps = {
   vertical?: boolean;
   /** Callback on drag */
   onChange?: (sizes: number[]) => void;
+  /** Callback when user stops dragging the sash*/
+  onDragEnd?: (sizes: number[]) => void;
   /** Callback on reset */
   onReset?: () => void;
   /** Callback on visibility change */
@@ -133,9 +135,10 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       snap = false,
       vertical = false,
       onChange,
+      onDragEnd,
       onReset,
       onVisibleChange,
-    },
+    }: AllotmentProps,
     ref
   ) => {
     const containerRef = useRef<HTMLDivElement>(null!);
@@ -246,7 +249,8 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
       splitViewRef.current = new SplitView(
         containerRef.current,
         options,
-        onChange
+        onChange,
+        onDragEnd
       );
 
       splitViewRef.current.on("sashDragStart", () => {
@@ -446,6 +450,12 @@ const Allotment = forwardRef<AllotmentHandle, AllotmentProps>(
         splitViewRef.current.onDidChange = onChange;
       }
     }, [onChange]);
+    
+    useEffect(() => {
+      if (splitViewRef.current) {
+        splitViewRef.current.onDragEnd = onDragEnd;
+      }
+    }, [onDragEnd])
 
     useResizeObserver({
       ref: containerRef,

--- a/src/split-view/split-view.ts
+++ b/src/split-view/split-view.ts
@@ -310,6 +310,7 @@ interface SashDragState {
  */
 export class SplitView extends EventEmitter implements Disposable {
   public onDidChange: ((sizes: number[]) => void) | undefined;
+  public onDragEnd: ((sizes: number[]) => void) | undefined;
 
   /**  This {@link SplitView}'s orientation. */
   readonly orientation: Orientation;
@@ -362,7 +363,8 @@ export class SplitView extends EventEmitter implements Disposable {
   constructor(
     container: HTMLElement,
     options: SplitViewOptions = {},
-    onDidChange?: (sizes: number[]) => void
+    onDidChange?: (sizes: number[]) => void,
+    onDragEnd?: (sizes: number[]) => void
   ) {
     super();
 
@@ -372,6 +374,10 @@ export class SplitView extends EventEmitter implements Disposable {
 
     if (onDidChange) {
       this.onDidChange = onDidChange;
+    }
+
+    if (onDragEnd) {
+      this.onDragEnd = onDragEnd;
     }
 
     this.sashContainer = document.createElement("div");
@@ -903,6 +909,9 @@ export class SplitView extends EventEmitter implements Disposable {
     for (const item of this.viewItems) {
       item.enabled = true;
     }
+
+    const sizes = this.viewItems.map(i => i.size);
+    this.onDragEnd?.(sizes);
   };
 
   private getSashPosition(sash: Sash): number {

--- a/src/split-view/split-view.ts
+++ b/src/split-view/split-view.ts
@@ -310,7 +310,7 @@ interface SashDragState {
  */
 export class SplitView extends EventEmitter implements Disposable {
   public onDidChange: ((sizes: number[]) => void) | undefined;
-  public onDragEnd: ((sizes: number[]) => void) | undefined;
+  public onChangeEnd: ((sizes: number[]) => void) | undefined;
 
   /**  This {@link SplitView}'s orientation. */
   readonly orientation: Orientation;
@@ -364,7 +364,7 @@ export class SplitView extends EventEmitter implements Disposable {
     container: HTMLElement,
     options: SplitViewOptions = {},
     onDidChange?: (sizes: number[]) => void,
-    onDragEnd?: (sizes: number[]) => void
+    onChangeEnd?: (sizes: number[]) => void
   ) {
     super();
 
@@ -376,8 +376,8 @@ export class SplitView extends EventEmitter implements Disposable {
       this.onDidChange = onDidChange;
     }
 
-    if (onDragEnd) {
-      this.onDragEnd = onDragEnd;
+    if (onChangeEnd) {
+      this.onChangeEnd = onChangeEnd;
     }
 
     this.sashContainer = document.createElement("div");
@@ -697,6 +697,11 @@ export class SplitView extends EventEmitter implements Disposable {
     return this.viewItems[index].size;
   }
 
+  /** Returns all of the sizes of the split-view's {@link View views}. */
+  public getViewSizes(): number[] {
+    return this.viewItems.map((i) => i.size);
+  }
+
   /**
    * Returns whether the {@link View view} is visible.
    *
@@ -911,7 +916,7 @@ export class SplitView extends EventEmitter implements Disposable {
     }
 
     const sizes = this.viewItems.map(i => i.size);
-    this.onDragEnd?.(sizes);
+    this.onChangeEnd?.(sizes);
   };
 
   private getSashPosition(sash: Sash): number {


### PR DESCRIPTION
Hi! I was running into an issue with `allotment` where its `onChange` handler's constant-firing was creating some performance issues in a webapp that I'm working on.

I'd like to propose adding an `onChangeEnd` callback, which gets called exactly-once when the user either (a) stops-dragging-with-their-mouse or (b) clicks Reset for the layout.