### PR TITLE
chore: support new ts module resolution(bundler)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "version": "1.19.0",
   "description": "React split-pane component",
   "exports": {
-    ".": "./dist/modern.mjs",
-    "./dist/": "./dist/"
+    ".": {
+      "main": "./dist/modern.mjs",
+      "types": "./dist/types/src/index.d.ts"
+    },
+    "./dist/": {
+      "main": "./dist/",
+      "types": "./dist/types/src/index.d.ts"
+    }
   },
   "main": "./dist/legacy.js",
   "module": "./dist/module.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,7 +20,7 @@ const config = {
   external: [/@babel\/runtime/, ...Object.keys(globals)],
   output: [
     {
-      file: meta.exports["."],
+      file: meta.exports["."].main,
       format: "es",
       plugins: [
         getBabelOutputPlugin({


### PR DESCRIPTION
This pr support new ts module resolution option (node16, nodenext, bundler)

![image](https://github.com/johnwalley/allotment/assets/13764936/78950fe7-739b-4a86-94b5-1e047bd2601f)

fix this import error