### PR TITLE
fix: correct dist exports condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "import": "./dist/modern.mjs",
       "types": "./dist/types/src/index.d.ts"
     },
-    "./dist/": "./dist/"
+    "./dist/*": "./dist/*"
   },
   "main": "./dist/legacy.js",
   "module": "./dist/module.js",


### PR DESCRIPTION
Use a subpath pattern instead of specifying the directory (which is not valid from my understanding, though bundlers will often just "make it work")