### PR TITLE
#414 #415 Fixed low priority panels resizing first when visibility of panes is changed

### DIFF
--- a/src/split-view/split-view.ts
+++ b/src/split-view/split-view.ts
@@ -1070,14 +1070,33 @@ export class SplitView extends EventEmitter implements Disposable {
     const contentSize = this.viewItems.reduce((r, i) => r + i.size, 0);
     let emptyDelta = this.size - contentSize;
 
-    const indexes = range(this.viewItems.length - 1, -1, -1);
+    const indexes = range(0, this.viewItems.length);
+    const sortedIndexes: number[] = [];
+
+    const lowPriorityIndexes = indexes.filter(
+      (i) => this.viewItems[i].priority === LayoutPriority.Low,
+    );
+
+    const normalPriorityIndexes = indexes.filter(
+      (i) => this.viewItems[i].priority === LayoutPriority.Normal,
+    );
+
+    const highPriorityIndexes = indexes.filter(
+      (i) => this.viewItems[i].priority === LayoutPriority.High,
+    );
+
+    sortedIndexes.push(
+      ...highPriorityIndexes,
+      ...normalPriorityIndexes,
+      ...lowPriorityIndexes,
+    );
 
     if (typeof lowPriorityIndex === "number") {
-      pushToEnd(indexes, lowPriorityIndex);
+      pushToEnd(sortedIndexes, lowPriorityIndex);
     }
 
-    for (let i = 0; emptyDelta !== 0 && i < indexes.length; i++) {
-      const item = this.viewItems[indexes[i]];
+    for (let i = 0; emptyDelta !== 0 && i < sortedIndexes.length; i++) {
+      const item = this.viewItems[sortedIndexes[i]];
       const size = clamp(
         item.size + emptyDelta,
         item.minimumSize,


### PR DESCRIPTION
Added priority sorting logic to the distributeEmptySpace method to ensure high priority windows are resized first when we change the visibility of a pane. The issue occurred when this method was invoked from setViewVisible, but from my understanding this logic should always be applied. Please correct me if i'm wrong.