### PR TITLE
Fix descriptor comment

### DIFF
--- a/src/split-view/split-view.ts
+++ b/src/split-view/split-view.ts
@@ -92,7 +92,7 @@ export interface SplitViewOptions {
 
   /**
    * An initial description of this {@link SplitView} instance, allowing
-   * to initialze all views within the ctor.
+   * to initialize all views within the ctor.
    */
   readonly descriptor?: SplitViewDescriptor;
 


### PR DESCRIPTION
## Summary
- fix a typo in the `descriptor` option documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68481fd668a88330b7e559e403daa327